### PR TITLE
Add POST command execution endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,34 @@ Or Twitter/X https://x.com/wonderwhy_er
 ## License
 
 The project is licensed under the MIT License.
+
+## Command execution endpoints
+
+The original command endpoint remains available for backwards compatibility:
+
+```http
+GET /api/runTerminalScript?command=pwd
+```
+
+For new integrations, prefer sending commands in a JSON request body so command strings do not appear in URL logs:
+
+```http
+POST /api/runTerminalScript
+Content-Type: application/json
+
+{
+  "command": "pwd"
+}
+```
+
+A versioned alias is also available for integrations that prefer a stable v1 route:
+
+```http
+POST /v1/commands/execute
+Content-Type: application/json
+
+{
+  "command": "pwd"
+}
+```
+

--- a/api/terminal.js
+++ b/api/terminal.js
@@ -63,12 +63,82 @@ let output = "";
  *         description: Bad request (e.g., missing command parameter).
  *       '500':
  *         description: Internal server error (e.g., error executing command).
+
+ *   post:
+ *     summary: Execute a shell command using a JSON request body.
+ *     description: Compatibility endpoint for executing arbitrary shell commands without placing the command in the query string. Prefer this over GET so commands do not appear in URL logs.
+ *     operationId: runTerminalScriptPost
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - command
+ *             properties:
+ *               command:
+ *                 type: string
+ *                 description: The shell command to execute.
+ *     responses:
+ *       '200':
+ *         description: Command executed successfully.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                 output:
+ *                   type: string
+ *       '400':
+ *         description: Bad request (e.g., missing command parameter).
+ *       '500':
+ *         description: Internal server error (e.g., error executing command).
+ */
+
+/**
+ * @openapi
+ * /v1/commands/execute:
+ *   post:
+ *     summary: Execute a shell command using a JSON request body.
+ *     description: Versioned command execution endpoint. It behaves like POST /api/runTerminalScript, but gives integrations a stable POST endpoint that avoids putting commands in query strings.
+ *     operationId: executeCommand
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - command
+ *             properties:
+ *               command:
+ *                 type: string
+ *                 description: The shell command to execute.
+ *     responses:
+ *       '200':
+ *         description: Command executed successfully.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                 output:
+ *                   type: string
+ *       '400':
+ *         description: Bad request (e.g., missing command parameter).
+ *       '500':
+ *         description: Internal server error (e.g., error executing command).
  */
 function terminalHandler(req, res) {
     console.log('execute command');
     res.setHeader('Access-Control-Allow-Origin', 'https://chat.openai.com');
     res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
-    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, openai-conversation-id, openai-ephemeral-user-id');
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization, openai-conversation-id, openai-ephemeral-user-id');
     res.setHeader('Access-Control-Allow-Credentials', true);
 
     // Handle preflight request (OPTIONS method)
@@ -77,8 +147,10 @@ function terminalHandler(req, res) {
         return;
     }
 
-    const command = req.query.command;
-    if (!command) {
+    const command = req.method === 'POST'
+        ? (req.body && req.body.command) || req.query.command
+        : req.query.command;
+    if (!command || typeof command !== 'string') {
         return res.status(400).json({message: 'Command parameter is required.'});
     }
 

--- a/serverModules/apiRoutes.js
+++ b/serverModules/apiRoutes.js
@@ -23,6 +23,8 @@ module.exports = {
         });
         const readEditTextFileHandler = require('../api/readEditTextFile2Handler')(getURL);
         app.get('/api/runTerminalScript', terminalHandler);
+        app.post('/api/runTerminalScript', terminalHandler);
+        app.post('/v1/commands/execute', terminalHandler);
         /*const createAppHandler = createAppHandlerWithUrl(getURL);
         app.route('/api/apps')
               .post(createAppHandler)


### PR DESCRIPTION
## Summary

Adds POST alternatives for command execution while keeping the existing GET endpoint unchanged for backwards compatibility.

New routes:

- `POST /api/runTerminalScript`
- `POST /v1/commands/execute`

Both accept a JSON body:

```json
{ "command": "pwd" }
```

## Why

The existing `GET /api/runTerminalScript?command=...` route works, but putting commands in the query string can leak command text into browser, proxy or server logs. GPT Actions and other API clients can send JSON request bodies, so POST is a safer default for new integrations.

## Compatibility

- Existing GET route is unchanged.
- The POST `/api/runTerminalScript` endpoint reuses the same handler.
- `/v1/commands/execute` is a versioned alias for integrations that prefer a stable v1 route.
- OpenAPI comments and README examples are updated.
- `Authorization` is allowed in CORS preflight headers for bearer-authenticated GPT Actions.

## Validation

```bash
node --check api/terminal.js
node --check serverModules/apiRoutes.js
```
